### PR TITLE
feat: Add Github Action yml to auto deploy.

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -1,0 +1,29 @@
+name: Deploy Github Pages
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    env:
+      API_BASE: 'https://rpc.kraken.fm'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          persist-credentials: false
+  
+      - name: Install and Generate
+        run: |
+          yarn install
+          yarn generate
+          cp dist/index.html dist/404.html
+      - name: Deploy
+        uses: JamesIves/github-pages-deploy-action@releases/v3
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH: gh-pages
+          FOLDER: dist

--- a/src/static/CNAME
+++ b/src/static/CNAME
@@ -1,0 +1,1 @@
+mornin.fm

--- a/src/static/CNAME
+++ b/src/static/CNAME
@@ -1,1 +1,1 @@
-mornin.fm
+fm.viticis.com


### PR DESCRIPTION
Add a github action, when some changes push to master branch, this action will auto deploy to github pages.

Some tips:

- You must have your own domain name, because the project uses relative paths, if you use github's domain name, it's like this `<user>.github.io/mornin.fm/`, but it will go to `<user>.github.io/` to find js and css.
- Configure a CNAME record with your DNS provider, modify the content of `src/CNAME` to your custom domain name.
- Github does not recommend using the root domain name, but using the subdomain name. If the root domain name is used as the CNAME, see [configuring-an-apex-domain](https://docs.github.com/en/pages/configuring-a-custom-domain-for-your-github-pages-site/managing-a-custom-domain-for-your-github-pages-site#configuring-an-apex-domain).
- If you use [kraken](https://github.com/MixinNetwork/kraken) to build your own backend service, modify `env.API_BASE` in `.github/workflows/master.yml`
- Finally, go to your forked repository, select Settings -> Pages, select `gh-pages` branch to save.
